### PR TITLE
Fix psssodls_string

### DIFF
--- a/src/psssodls/main.py
+++ b/src/psssodls/main.py
@@ -1,16 +1,10 @@
-"""
-Python package `psssodls` generates Minion 3 input files
-for pandiagonal strongly symmetric self-orthogonal diagonal
-latin squares (PSSSODLS).
-"""
-
 import sys
 
 from math import sqrt
 
 from psssodls.constraints import alldiff, sdk_positions_box
 from psssodls.constraints import psumg, pandiagonal_sum_a, psuml, pandiagonal_sum_b
-from psssodls.constraints import ell, ellell
+from psssodls.constraints import ell, ellell, vecneq
 
 def begin(n):
   return """\

--- a/src/psssodls/main.py
+++ b/src/psssodls/main.py
@@ -2,6 +2,8 @@ import sys
 
 from math import sqrt
 
+from psssodls.constraints import alldiff, psumg, pandiagonal_sum_a, psuml, pandiagonal_sum_b, ellell, vecneq
+
 def begin(n):
   return """\
 MINION 3

--- a/src/psssodls/main.py
+++ b/src/psssodls/main.py
@@ -2,10 +2,6 @@ import sys
 
 from math import sqrt
 
-from psssodls.constraints import alldiff, sdk_positions_box
-from psssodls.constraints import psumg, pandiagonal_sum_a, psuml, pandiagonal_sum_b
-from psssodls.constraints import ell, ellell, vecneq
-
 def begin(n):
   return """\
 MINION 3

--- a/src/psssodls/main.py
+++ b/src/psssodls/main.py
@@ -2,7 +2,7 @@ import sys
 
 from math import sqrt
 
-from psssodls.constraints import alldiff, psumg, pandiagonal_sum_a, psuml, pandiagonal_sum_b, ellell, vecneq
+from psssodls.constraints import alldiff, psumg, pandiagonal_sum_a, psuml, pandiagonal_sum_b, ellell, vecneq, sdk_positions_box, ell
 
 def begin(n):
   return """\


### PR DESCRIPTION
All that was needed was to import `vecneq` from `psssodls.constraints`.